### PR TITLE
Use phoneme lengths to trim samples

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ piper-phonemize==1.1.0
 numpy<2
 torch<2
 torchaudio
+webrtcvad

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,3 @@ piper-phonemize==1.1.0
 numpy<2
 torch<2
 torchaudio
-webrtcvad


### PR DESCRIPTION
- Trim the samples using phoneme lengths
  - Fixes bug where ``min-phoneme-count`` with a batch size larger than 1 producing not properly aligned samples
- Changed resampling method name to avoid a depreciation warning