### PR TITLE
fix: PyTorch 2.6 compatibility in piper-sample-generator

### DIFF
--- a/generate_samples.py
+++ b/generate_samples.py
@@ -73,7 +73,7 @@ def generate_samples(
     _LOGGER.debug("Loading %s", model)
     model_path = Path(model)
 
-    torch_model = torch.load(model_path)
+    torch_model = torch.load(model_path, weights_only=False)
     torch_model.eval()
     _LOGGER.info("Successfully loaded the model")
 


### PR DESCRIPTION
Fix torch.load compatibility with PyTorch 2.6

Add weights_only=False parameter to torch.load() call in generate_samples.py to maintain compatibility with PyTorch 2.6, which changed the default value of weights_only from False to True. This allows loading models with custom classes like piper_train.vits.models.SynthesizerTrn.

Fixes model loading error: "Weights only load failed" when using PyTorch 2.6+