### PR TITLE
added piper_train directory to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ platforms = ["any"]
 zip-safe  = true
 
 [tool.setuptools.packages.find]
-include = ["piper_sample_generator*"]
+include = ["piper_sample_generator*", "piper_train*"]
 
 [tool.setuptools.package-data]
 piper_sample_generator = ["impulses/*.wav"]


### PR DESCRIPTION
Currently you get `ModuleNotFoundError: No module named 'piper_train'` when you install this via `pip install`.

This PR resolves the issue (#20) by adding the missing module.